### PR TITLE
Make image path relative

### DIFF
--- a/lancie-card.html
+++ b/lancie-card.html
@@ -49,7 +49,7 @@
         heading: String,
         image: {
           type: String,
-          value: '../images-optimized/lancie/logo_without_date.png'
+          value: 'images-optimized/lancie/logo_without_date.png'
         }
       },
 


### PR DESCRIPTION
For the new build system, base paths are automatically added, but they only apply to relative URLs. This PR makes the image path relative so it works with the automatic basepath rewrite.